### PR TITLE
pin version to 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM klaemo/couchdb:latest
+FROM klaemo/couchdb:1.6.1
 
 MAINTAINER Clemens Stolle klaemo@fastmail.fm
 


### PR DESCRIPTION
We shouldn't always pull the latest version of CouchDB. For now I propose to use 1.6.1.

Maybe we could switch to 2.0 in the future.